### PR TITLE
Fix typo in RoPE backward gradient

### DIFF
--- a/transformers_patch/rope.py
+++ b/transformers_patch/rope.py
@@ -31,9 +31,9 @@ class RotaryEmbedding(torch.autograd.Function):
     @torch.profiler.record_function("rope_bwd")
     @torch.compile
     @staticmethod
-    def backward(ctx, dq, qk):
+    def backward(ctx, dq, dk):
         cos, sin = ctx.saved_tensors
-        dq, dk = apply_rotary_pos_emb(dq, qk, cos, sin, ctx.unsqueeze_dim, False)
+        dq, dk = apply_rotary_pos_emb(dq, dk, cos, sin, ctx.unsqueeze_dim, False)
         return dq, dk, None, None, None
 
 


### PR DESCRIPTION
## Summary

Fix a typo in `RotaryEmbedding.backward` where the key gradient argument was named `qk` instead of `dk`.

## Validation

- Ran `python -m py_compile .\transformers_patch\rope.py`
- Confirmed no remaining `qk` references in `transformers_patch/rope.py`
